### PR TITLE
Create dynamic login experience

### DIFF
--- a/public/assets/css/login&signup.css
+++ b/public/assets/css/login&signup.css
@@ -14,11 +14,15 @@
 }
 
 .login-card {
-    width: min(480px, 100%);
+    width: min(500px, 100%);
     background: var(--white);
     border-radius: var(--radius-lg);
     box-shadow: var(--shadow-soft);
     padding: 56px 64px;
+}
+
+.login-card .lead {
+    color: var(--text-muted);
 }
 
 .logo img {
@@ -44,8 +48,12 @@
     border-radius: var(--radius-sm);
     padding: 12px 16px;
     font-size: 16px;
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
     background: var(--white);
+}
+
+.password-wrapper .input-wrapper {
+    padding-right: 52px;
 }
 
 .input-wrapper:focus {
@@ -54,12 +62,37 @@
     box-shadow: 0 0 0 4px rgba(76, 111, 255, 0.12);
 }
 
+.input-wrapper.is-invalid {
+    border-color: #fda29b;
+    background: #fff4f3;
+}
+
+.input-wrapper.is-valid {
+    border-color: #32d583;
+}
+
 .toggle-password {
+    position: absolute;
     right: 16px;
     top: 50%;
     transform: translateY(-50%);
     color: var(--text-muted);
     cursor: pointer;
+    border: 0;
+    background: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+
+.toggle-password:focus {
+    outline: none;
+    color: var(--primary);
+}
+
+.toggle-password i {
+    font-size: 18px;
 }
 
 .form-check-input:checked {
@@ -70,6 +103,11 @@
 .forget-pass {
     color: var(--primary);
     font-weight: 600;
+}
+
+.form-meta {
+    color: var(--text-muted);
+    font-weight: 500;
 }
 
 .fw-md {
@@ -93,6 +131,88 @@
     box-shadow: 0 16px 32px rgba(76, 111, 255, 0.2);
 }
 
+.login-btn:disabled {
+    opacity: 0.65;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.feedback-banner {
+    display: none;
+    padding: 14px 16px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+    margin-bottom: 32px;
+    border: 1px solid transparent;
+}
+
+.feedback-banner.is-visible {
+    display: block;
+}
+
+.feedback-banner.is-info {
+    background: rgba(76, 111, 255, 0.12);
+    border-color: rgba(76, 111, 255, 0.35);
+    color: var(--primary);
+}
+
+.feedback-banner.is-success {
+    background: rgba(52, 168, 83, 0.15);
+    border-color: rgba(52, 168, 83, 0.35);
+    color: #0f6b3c;
+}
+
+.feedback-banner.is-error {
+    background: rgba(217, 45, 32, 0.12);
+    border-color: rgba(217, 45, 32, 0.3);
+    color: #b42318;
+}
+
+.validation-message {
+    min-height: 18px;
+    font-size: 14px;
+    margin-top: 8px;
+    color: #b42318;
+}
+
+.divider {
+    position: relative;
+    text-transform: uppercase;
+    font-size: 12px;
+    color: var(--text-muted);
+    letter-spacing: 1.2px;
+}
+
+.divider::before,
+.divider::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    width: 40%;
+    height: 1px;
+    background: var(--border-color);
+}
+
+.divider::before {
+    left: 0;
+}
+
+.divider::after {
+    right: 0;
+}
+
+.divider-label {
+    background: var(--white);
+    padding: 0 8px;
+}
+
+.social-login {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
 .google-btn {
     border: 1px solid var(--border-color);
     border-radius: var(--radius-md);
@@ -109,6 +229,20 @@
 .google-btn:hover {
     border-color: var(--primary);
     box-shadow: 0 12px 24px rgba(16, 24, 40, 0.08);
+}
+
+.signup-prompt {
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.demo-tip {
+    font-size: 14px;
+    color: var(--text-muted);
+}
+
+.demo-tip strong {
+    color: var(--text-dark);
 }
 
 .right-side {
@@ -143,6 +277,85 @@
     transform: translate(-50%, -50%);
 }
 
+.right-side-content {
+    position: relative;
+    z-index: 1;
+    color: var(--white);
+    max-width: 520px;
+    padding: 72px 64px;
+    backdrop-filter: blur(0);
+}
+
+.right-side-title {
+    font-size: 36px;
+    line-height: 1.2;
+}
+
+.right-side-text {
+    font-size: 18px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.benefits-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 20px;
+}
+
+.benefits-list li {
+    position: relative;
+    padding-left: 36px;
+    font-size: 17px;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.benefits-list li::before {
+    content: "\f058";
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    position: absolute;
+    left: 0;
+    top: 4px;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.insight-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.insight-card {
+    background: rgba(255, 255, 255, 0.14);
+    border-radius: var(--radius-md);
+    padding: 20px 24px;
+    backdrop-filter: blur(6px);
+}
+
+.insight-label {
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 1.6px;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.insight-value {
+    display: block;
+    font-size: 30px;
+    font-weight: 700;
+    margin-top: 12px;
+}
+
+.insight-subtext {
+    display: block;
+    margin-top: 4px;
+    color: rgba(255, 255, 255, 0.7);
+    font-size: 14px;
+}
+
 @media (max-width: 1200px) {
     .left-side,
     .right-side {
@@ -151,6 +364,10 @@
 
     .login-card {
         padding: 48px;
+    }
+
+    .right-side-content {
+        padding: 64px 48px;
     }
 }
 
@@ -167,13 +384,15 @@
     }
 
     .right-side {
-        min-height: 320px;
+        min-height: 360px;
     }
 
-    .login-card {
-        margin: 0 auto;
-        padding: 40px 32px;
-        box-shadow: none;
+    .right-side-content {
+        padding: 56px 32px;
+    }
+
+    .insight-grid {
+        grid-template-columns: repeat(1, minmax(0, 1fr));
     }
 }
 
@@ -185,5 +404,10 @@
     .login-btn,
     .google-btn {
         padding: 12px 0;
+    }
+
+    .divider::before,
+    .divider::after {
+        width: 30%;
     }
 }

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -1,13 +1,366 @@
 (function () {
-    const togglePassword = document.getElementById('customtogglePassword');
-    const passwordField = document.getElementById('custompassword');
+    const passwordField = document.getElementById('password');
+    const togglePasswordButton = document.getElementById('togglePassword');
+    const toggleIcon = togglePasswordButton ? togglePasswordButton.querySelector('i') : null;
 
-    if (togglePassword && passwordField) {
-        togglePassword.addEventListener('click', () => {
-            const isHidden = passwordField.getAttribute('type') === 'password';
-            passwordField.setAttribute('type', isHidden ? 'text' : 'password');
-            togglePassword.classList.toggle('fa-eye');
-            togglePassword.classList.toggle('fa-eye-slash');
+    if (togglePasswordButton) {
+        togglePasswordButton.setAttribute('aria-pressed', 'false');
+        togglePasswordButton.setAttribute('title', 'Show password');
+    }
+
+    function setPasswordVisibility(isHidden) {
+        if (!passwordField || !togglePasswordButton) {
+            return;
+        }
+
+        passwordField.setAttribute('type', isHidden ? 'password' : 'text');
+        togglePasswordButton.setAttribute('aria-pressed', String(!isHidden));
+        togglePasswordButton.setAttribute('title', isHidden ? 'Show password' : 'Hide password');
+
+        if (toggleIcon) {
+            toggleIcon.classList.toggle('fa-eye', isHidden);
+            toggleIcon.classList.toggle('fa-eye-slash', !isHidden);
+        }
+    }
+
+    if (togglePasswordButton && passwordField) {
+        togglePasswordButton.addEventListener('click', () => {
+            const isCurrentlyHidden = passwordField.getAttribute('type') === 'password';
+            setPasswordVisibility(!isCurrentlyHidden);
         });
     }
+
+    const greetingHeading = document.getElementById('greetingHeading');
+    const subHeading = document.getElementById('subHeading');
+    let fallbackSubheading = subHeading ? subHeading.textContent : '';
+
+    if (greetingHeading && subHeading) {
+        const now = new Date();
+        const hour = now.getHours();
+        const greetingPrefix = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening';
+        const titles = ['Explorer', 'Maker', 'Strategist', 'Dreamer', 'Leader', 'Trailblazer'];
+        const moodLines = [
+            'Use demo@dazzly.com with Password123! for an instant walkthrough.',
+            'Check analytics the moment you land to keep decisions data-backed.',
+            'Sync with your team faster by reviewing today’s automations.',
+            'Queue up your customer journeys and let Dazzly handle the flow.',
+            'Need inspiration? Visit the playbook library right after sign in.',
+            'Every login unlocks a clearer picture of your customer journey.'
+        ];
+        const dynamicTitle = titles[now.getDay() % titles.length];
+        const dynamicMood = moodLines[(now.getMinutes() + now.getDay()) % moodLines.length];
+
+        greetingHeading.textContent = `${greetingPrefix}, ${dynamicTitle}!`;
+        subHeading.textContent = dynamicMood;
+        fallbackSubheading = dynamicMood;
+    }
+
+    function setSubheading(text) {
+        if (!subHeading) {
+            return;
+        }
+
+        subHeading.textContent = text;
+    }
+
+    const tips = [
+        'Use demo@dazzly.com with Password123! for an instant walkthrough.',
+        'Bookmark your dashboard to jump straight back to insights next time.',
+        'Schedule a morning automation review to keep campaigns on track.',
+        'Invite a teammate after login so they can follow along in real time.'
+    ];
+
+    let tipIndex = 0;
+    let isBenefitFocused = false;
+
+    function rotateTips() {
+        if (!subHeading || !tips.length) {
+            return;
+        }
+
+        fallbackSubheading = tips[tipIndex];
+        if (!isBenefitFocused) {
+            setSubheading(fallbackSubheading);
+        }
+        tipIndex = (tipIndex + 1) % tips.length;
+        window.setTimeout(rotateTips, 12000);
+    }
+
+    if (subHeading) {
+        window.setTimeout(rotateTips, 12000);
+    }
+
+    const form = document.getElementById('loginForm');
+    const emailInput = document.getElementById('email');
+    const rememberCheckbox = document.getElementById('rememberMe');
+    const loginButton = document.getElementById('loginButton');
+    const feedbackBanner = document.getElementById('loginFeedback');
+    const emailError = document.getElementById('emailError');
+    const passwordError = document.getElementById('passwordError');
+
+    const rememberedEmailKey = 'dazzly.rememberedEmail';
+
+    if (emailInput && rememberCheckbox) {
+        const storedEmail = window.localStorage.getItem(rememberedEmailKey);
+        if (storedEmail) {
+            emailInput.value = storedEmail;
+            rememberCheckbox.checked = true;
+        }
+    }
+
+    function clearValidationState(input, messageElement) {
+        if (!input || !messageElement) {
+            return;
+        }
+
+        input.classList.remove('is-invalid', 'is-valid');
+        messageElement.textContent = '';
+    }
+
+    function setValidationState(input, messageElement, isValid, message) {
+        if (!input || !messageElement) {
+            return;
+        }
+
+        input.classList.toggle('is-invalid', !isValid && Boolean(message));
+        input.classList.toggle('is-valid', isValid && input.value.trim() !== '');
+        messageElement.textContent = message || '';
+    }
+
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+    function validateEmail(showMessage = true) {
+        if (!emailInput || !emailError) {
+            return true;
+        }
+
+        const value = emailInput.value.trim();
+
+        if (!value) {
+            if (showMessage) {
+                setValidationState(emailInput, emailError, false, 'Email is required.');
+            }
+            return false;
+        }
+
+        if (!emailPattern.test(value)) {
+            if (showMessage) {
+                setValidationState(emailInput, emailError, false, 'Please provide a valid email address.');
+            }
+            return false;
+        }
+
+        if (showMessage) {
+            setValidationState(emailInput, emailError, true, '');
+        }
+        return true;
+    }
+
+    function validatePassword(showMessage = true) {
+        if (!passwordField || !passwordError) {
+            return true;
+        }
+
+        const value = passwordField.value;
+
+        if (!value.trim()) {
+            if (showMessage) {
+                setValidationState(passwordField, passwordError, false, 'Password is required.');
+            }
+            return false;
+        }
+
+        if (value.length < 8) {
+            if (showMessage) {
+                setValidationState(passwordField, passwordError, false, 'Use at least 8 characters.');
+            }
+            return false;
+        }
+
+        if (showMessage) {
+            setValidationState(passwordField, passwordError, true, '');
+        }
+        return true;
+    }
+
+    function updateButtonState() {
+        if (!loginButton) {
+            return;
+        }
+
+        const canSubmit = validateEmail(false) && validatePassword(false);
+        loginButton.disabled = !canSubmit;
+    }
+
+    function updateFeedback(type, message) {
+        if (!feedbackBanner) {
+            return;
+        }
+
+        feedbackBanner.className = 'feedback-banner';
+
+        if (!message) {
+            feedbackBanner.textContent = '';
+            return;
+        }
+
+        feedbackBanner.textContent = message;
+        feedbackBanner.classList.add('is-visible');
+
+        const map = {
+            success: 'is-success',
+            error: 'is-error',
+            info: 'is-info'
+        };
+
+        feedbackBanner.classList.add(map[type] || map.info);
+    }
+
+    function clearFeedback() {
+        updateFeedback('', '');
+    }
+
+    if (emailInput) {
+        emailInput.addEventListener('input', () => {
+            validateEmail();
+            updateButtonState();
+            clearFeedback();
+        });
+        emailInput.addEventListener('blur', () => validateEmail());
+    }
+
+    if (passwordField) {
+        passwordField.addEventListener('input', () => {
+            validatePassword();
+            updateButtonState();
+            clearFeedback();
+        });
+        passwordField.addEventListener('blur', () => validatePassword());
+    }
+
+    updateButtonState();
+
+    const credentials = {
+        'demo@dazzly.com': 'Password123!',
+        'teamlead@dazzly.com': 'LeadFlow!24',
+        'insights@dazzly.com': 'Trends#2024'
+    };
+
+    if (form && loginButton) {
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+
+            const isEmailValid = validateEmail();
+            const isPasswordValid = validatePassword();
+
+            if (!isEmailValid || !isPasswordValid) {
+                updateButtonState();
+                return;
+            }
+
+            updateFeedback('info', 'Checking your credentials...');
+
+            const originalButtonContent = loginButton.innerHTML;
+            loginButton.disabled = true;
+            loginButton.innerHTML = '<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>Logging in...';
+
+            const emailValue = emailInput ? emailInput.value.trim().toLowerCase() : '';
+            const passwordValue = passwordField ? passwordField.value : '';
+            const remember = rememberCheckbox ? rememberCheckbox.checked : false;
+
+            window.setTimeout(() => {
+                const isAuthenticated = Boolean(emailValue && credentials[emailValue] === passwordValue);
+
+                if (isAuthenticated) {
+                    updateFeedback('success', 'Welcome back! Redirecting you to your dashboard...');
+
+                    if (remember && emailInput) {
+                        window.localStorage.setItem(rememberedEmailKey, emailInput.value.trim());
+                    } else {
+                        window.localStorage.removeItem(rememberedEmailKey);
+                    }
+
+                    if (passwordField) {
+                        passwordField.value = '';
+                        clearValidationState(passwordField, passwordError);
+                    }
+                } else {
+                    updateFeedback('error', "The credentials you entered didn't match our records. Try the demo account above.");
+                }
+
+                loginButton.disabled = false;
+                loginButton.innerHTML = originalButtonContent;
+                updateButtonState();
+            }, 1200);
+        });
+    }
+
+    const liveSessions = document.getElementById('liveSessions');
+    const newSignups = document.getElementById('newSignups');
+    const newSignupsHint = document.getElementById('newSignupsHint');
+
+    function updateMetrics() {
+        if (!liveSessions && !newSignups && !newSignupsHint) {
+            return;
+        }
+
+        const sessions = Math.floor(60 + Math.random() * 40);
+        const signups = Math.floor(50 + Math.random() * 60);
+
+        if (liveSessions) {
+            liveSessions.textContent = `${sessions}`;
+        }
+
+        if (newSignups) {
+            newSignups.textContent = `${signups}`;
+        }
+
+        if (newSignupsHint) {
+            const progress = Math.min(100, Math.round((signups / 120) * 100));
+            newSignupsHint.textContent = `Daily goal: 120 · ${progress}% complete`;
+        }
+
+        window.setTimeout(updateMetrics, 7000);
+    }
+
+    updateMetrics();
+
+    const benefitMessages = {
+        automation: 'Automations run quietly in the background so you can focus on strategy.',
+        analytics: 'Dashboards refresh as data arrives to keep your team informed.',
+        collaboration: 'Teammates stay aligned with instant alerts and shared playbooks.'
+    };
+
+    const benefits = document.querySelectorAll('.benefits-list [data-benefit]');
+
+    benefits.forEach((benefit) => {
+        const key = benefit.getAttribute('data-benefit');
+        const message = (key && benefitMessages[key]) || fallbackSubheading;
+
+        benefit.addEventListener('mouseenter', () => {
+            isBenefitFocused = true;
+            if (message) {
+                setSubheading(message);
+            }
+        });
+
+        benefit.addEventListener('focus', () => {
+            isBenefitFocused = true;
+            if (message) {
+                setSubheading(message);
+            }
+        });
+
+        benefit.addEventListener('mouseleave', () => {
+            isBenefitFocused = false;
+            setSubheading(fallbackSubheading);
+        });
+
+        benefit.addEventListener('blur', () => {
+            isBenefitFocused = false;
+            setSubheading(fallbackSubheading);
+        });
+
+        benefit.setAttribute('tabindex', '0');
+    });
 })();

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,12 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dazzly - Login</title>
+    <meta name="description" content="Log in to your Dazzly workspace to continue managing automations, analytics, and customer experiences.">
+    <title>Dazzly &mdash; Login</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick-theme.min.css">
     <link rel="stylesheet" href="{{ asset('assets/css/main-page.css') }}">
     <link rel="stylesheet" href="{{ asset('assets/css/login&signup.css') }}">
 </head>
@@ -19,46 +18,87 @@
     <div class="main-sec">
         <div class="left-side">
             <div class="login-card">
-                <a href="/" class="logo d-flex align-items-center gap-3 mb-5">
+                <a href="/" class="logo d-flex align-items-center gap-3 mb-5 text-decoration-none">
                     <img src="{{ asset('assets/img/Logo.svg') }}" width="66" height="80" alt="Dazzly Logo">
                     <div class="logo-text">Dazzly</div>
                 </a>
-                <h1 class="fw-bold">LOG IN</h1>
-                <p style="font-size: 18px;" class="mb-5">Enter credentials to access your account</p>
-                <form action="#" class="form">
-                    <div class="mb-3">
+                <h1 class="fw-bold mb-2" id="greetingHeading">Welcome Back</h1>
+                <p class="lead mb-4" id="subHeading">Log in to pick up where you left off.</p>
+                <div class="feedback-banner" id="loginFeedback" role="alert" aria-live="polite"></div>
+                <form id="loginForm" class="form" novalidate>
+                    <div class="mb-4">
                         <label for="email" class="label">Email Address</label>
-                        <input id="email" type="email" placeholder="Enter your email" class="input-wrapper" required>
+                        <input id="email" name="email" type="email" placeholder="Enter your email" class="input-wrapper"
+                            autocomplete="email" required>
+                        <p class="validation-message" id="emailError" role="alert"></p>
                     </div>
-                    <label for="custompassword" class="label">Password</label>
-                    <div class="mb-3 position-relative">
-                        <input type="password" class="form-control input-wrapper" id="custompassword" placeholder="Enter your password" required>
-                        <i class="fa fa-eye toggle-password position-absolute" id="customtogglePassword" aria-hidden="true"></i>
+                    <div class="mb-4">
+                        <label for="password" class="label">Password</label>
+                        <div class="position-relative password-wrapper">
+                            <input type="password" class="input-wrapper" id="password" name="password"
+                                placeholder="Enter your password" autocomplete="current-password" minlength="8" required>
+                            <button type="button" class="toggle-password" id="togglePassword"
+                                aria-label="Toggle password visibility">
+                                <i class="fa fa-eye" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <p class="validation-message" id="passwordError" role="alert"></p>
                     </div>
-                    <div class="d-flex justify-content-between align-items-center flex-wrap mb-5">
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-5 form-meta">
                         <div class="form-check">
                             <input class="form-check-input" type="checkbox" id="rememberMe">
                             <label class="form-check-label" for="rememberMe">
-                                Remember Me
+                                Remember Me on this device
                             </label>
                         </div>
                         <a href="#" class="text-decoration-none forget-pass">Forgot Password?</a>
                     </div>
-                    <button type="submit" class="login-btn mb-5 border-0 w-100">Log In</button>
+                    <button type="submit" id="loginButton" class="login-btn mb-4 border-0 w-100">Log In</button>
                 </form>
-                <span style="font-size: 14px;" class="d-block text-center fw-md mb-3">Or login with</span>
-                <a href="#" class="google-btn mb-3 text-decoration-none">
-                    <img src="{{ asset('assets/img/google-icon.svg') }}" width="26" height="26" alt="Google Icon" loading="lazy">
-                    Google
-                </a>
-                <span style="font-size: 14px;" class="d-block text-center">Don’t have an account? <a href="#" class="text-primary fw-bold">Sign up</a></span>
+                <p class="demo-tip text-center mb-4">Try our demo credentials: <strong>demo@dazzly.com</strong> / <strong>Password123!</strong></p>
+                <div class="divider text-center mb-4">
+                    <span class="divider-label">or continue with</span>
+                </div>
+                <div class="social-login">
+                    <a href="#" class="google-btn mb-3 text-decoration-none">
+                        <img src="{{ asset('assets/img/google-icon.svg') }}" width="26" height="26" alt="Google Icon"
+                            loading="lazy">
+                        Google
+                    </a>
+                </div>
+                <div class="signup-prompt text-center">
+                    <span>Don’t have an account?</span>
+                    <a href="#" class="text-primary fw-bold ms-1">Create one now</a>
+                </div>
             </div>
         </div>
-        <div class="right-side"></div>
+        <div class="right-side">
+            <div class="right-side-content">
+                <span class="badge rounded-pill text-bg-light text-uppercase mb-4">Dashboard Preview</span>
+                <h2 class="right-side-title mb-3">Stay in sync with your customer journey</h2>
+                <p class="right-side-text mb-5">Dazzly keeps every automation, insight, and conversation aligned so your team
+                    can deliver remarkable experiences in real time.</p>
+                <div class="insight-grid mb-5">
+                    <div class="insight-card">
+                        <span class="insight-label">Live Sessions</span>
+                        <span class="insight-value" id="liveSessions">--</span>
+                        <span class="insight-subtext">Updating continuously</span>
+                    </div>
+                    <div class="insight-card">
+                        <span class="insight-label">New Signups</span>
+                        <span class="insight-value" id="newSignups">--</span>
+                        <span class="insight-subtext" id="newSignupsHint">Daily goal: 120</span>
+                    </div>
+                </div>
+                <ul class="benefits-list">
+                    <li data-benefit="automation">Automate repetitive work and focus on the moments that matter most.</li>
+                    <li data-benefit="analytics">Visualize performance with dashboards that update as your team acts.</li>
+                    <li data-benefit="collaboration">Collaborate with teammates using shared playbooks and real-time alerts.</li>
+                </ul>
+            </div>
+        </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.9.0/slick.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ asset('assets/js/main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- rebuild the login Blade view with a dynamic form, demo credentials prompt, and a live insights sidebar
- refresh the login stylesheet to cover validation feedback, social auth divider, and the dashboard preview presentation
- expand the frontend script to handle greetings, validation, remember-me storage, metric animations, and contextual benefit messaging

## Testing
- `npm run build`
- `php artisan test` *(fails: missing vendor dependencies; composer install blocked by upstream 403 responses)*

------
https://chatgpt.com/codex/tasks/task_b_68d492ed8e24832eac484946a708a2ad